### PR TITLE
Use conventions instead of paths for ignored

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -24,6 +24,8 @@ exports.config =
 
   paths:
     public: './public'
+
+  conventions:
     ignored: /template-/g
 
   minify: true


### PR DESCRIPTION
There was a warning when building that paths.ignored has been moved to
conventions.ignored. I updated this in the config file accordingly.
